### PR TITLE
Add Vue filters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.0] - 2018-02-23
+
+### Added
+
+- `default`, `money` and `percentage` Vue filters
+
+- `formatNumber` helper function
+
 ## [1.0.0] - 2018-02-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "maxfactor-vue-support",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maxfactor-vue-support",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "A collection of support helpers for Vue and Javascript projects",
     "main": "dist/index.js",
     "files": [

--- a/src/Filters/DefaultFilter.js
+++ b/src/Filters/DefaultFilter.js
@@ -1,0 +1,14 @@
+/**
+ * Set a default value to be used when there is no base value.
+ *
+ * @param  {String} value        Base value
+ * @param  {String} defaultValue Default value
+ * @return {String}              Value
+ */
+const Default = (value, defaultValue) => {
+    if (!value && defaultValue) return defaultValue
+
+    return value
+}
+
+export default Default

--- a/src/Filters/MoneyFilter.js
+++ b/src/Filters/MoneyFilter.js
@@ -1,5 +1,3 @@
-import formatNumber from '../Modules/FormatNumber'
-
 /**
  * Format a given value to a monetary value.
  *
@@ -9,11 +7,12 @@ import formatNumber from '../Modules/FormatNumber'
 const Money = (value) => {
     if (value === null) return ''
 
-    return formatNumber(value)
+    return parseFloat(value)
         .toLocaleString('en-GB', {
             style: 'currency',
             currency: 'GBP',
             currencyDisplay: 'symbol',
+            minimumFractionDigits: 2,
         })
 }
 

--- a/src/Filters/MoneyFilter.js
+++ b/src/Filters/MoneyFilter.js
@@ -1,0 +1,20 @@
+import formatNumber from '../Modules/FormatNumber'
+
+/**
+ * Format a given value to a monetary value.
+ *
+ * @param  {String} value Value to format
+ * @return {String}       Formatted monetary value
+ */
+const Money = (value) => {
+    if (value === null) return ''
+
+    return formatNumber(value)
+        .toLocaleString('en-GB', {
+            style: 'currency',
+            currency: 'GBP',
+            currencyDisplay: 'symbol',
+        })
+}
+
+export default Money

--- a/src/Filters/PercentageFilter.js
+++ b/src/Filters/PercentageFilter.js
@@ -1,0 +1,15 @@
+import formatNumber from '../Modules/FormatNumber'
+
+/**
+ * Format a given value to a percentage value.
+ *
+ * @param  {String} value Value to format
+ * @return {String}       Formatted percentage value
+ */
+const Percentage = (value) => {
+    if (value === null) return ''
+
+    return `${formatNumber(value)}%`
+}
+
+export default Percentage

--- a/src/Modules/FormatNumber.js
+++ b/src/Modules/FormatNumber.js
@@ -1,0 +1,16 @@
+/**
+ * Format a given string to a number with two decimal places.
+ *
+ * @param  {String} value Value to format
+ * @return {String}       Formatted value
+ */
+const FormatNumber = (value) => {
+    const formattedValue = value
+        .toLocaleString('en-GB', {
+            minimumFractionDigits: 2,
+        })
+
+    return parseFloat(formattedValue)
+}
+
+export default FormatNumber

--- a/src/Modules/FormatNumber.js
+++ b/src/Modules/FormatNumber.js
@@ -1,16 +1,12 @@
 /**
- * Format a given string to a number with two decimal places.
+ * Format a given string to a 'number' with two decimal places.
  *
  * @param  {String} value Value to format
  * @return {String}       Formatted value
  */
-const FormatNumber = (value) => {
-    const formattedValue = value
-        .toLocaleString('en-GB', {
-            minimumFractionDigits: 2,
-        })
-
-    return parseFloat(formattedValue)
-}
+const FormatNumber = value => parseFloat(value)
+    .toLocaleString('en-GB', {
+        minimumFractionDigits: 2,
+    })
 
 export default FormatNumber

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
+// Modules
 import FormatNumber from './Modules/FormatNumber'
 
+// Vue Mixins
 import FormMixin from './Mixins/FormMixin'
 
+// Vue Filters
 import DefaultFilter from './Filters/DefaultFilter'
 import MoneyFilter from './Filters/MoneyFilter'
 import PercentageFilter from './Filters/PercentageFilter'

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,26 @@
+import FormatNumber from './Modules/FormatNumber'
+
 import FormMixin from './Mixins/FormMixin'
+
+import DefaultFilter from './Filters/DefaultFilter'
+import MoneyFilter from './Filters/MoneyFilter'
+import PercentageFilter from './Filters/PercentageFilter'
 
 const Maxfactor = {
     install(Vue) {
         Vue.mixin(FormMixin)
+        Vue.filter('default', DefaultFilter)
+        Vue.filter('money', MoneyFilter)
+        Vue.filter('percentage', PercentageFilter)
     },
 }
 
 export default Maxfactor
 
 export {
+    FormatNumber,
     FormMixin,
+    DefaultFilter,
+    MoneyFilter,
+    PercentageFilter,
 }


### PR DESCRIPTION
Added the following Vue filters:

- `default` (Set a default value to be used when there is no base value)
- `money` (Format a given value to a monetary value)
- `percentage` (Format a given value to a percentage value)

Added the following helper function:

- `formatNumber` (Format a given string to a number with two decimal places)