### PR TITLE
Combined form mixin

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2018-06-01
+
+### Changed
+
+- `FormMixin` module. Now both sets and checks local and root state form errors to provide better compatibility when working with sub-components.
+
 ## [1.1.1] - 2018-03-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "maxfactor-vue-support",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/Mixins/FormMixin.js
+++ b/src/Mixins/FormMixin.js
@@ -23,18 +23,29 @@ export default {
     },
 
     computed: {
+        formErrors: {
+            get() {
+                return Object.assign({}, this.form.errors, this.$root.form.errors)
+            },
+            set(newValue) {
+                this.$set(this.form, 'errors', newValue)
+                this.$set(this.$root.form, 'errors', newValue)
+            },
+        },
+
         formIsLoading: {
             get() {
                 return this.form.loading || this.$root.isLoading
             },
-            set(value) {
-                this.form.loading = value
+            set(newValue) {
+                this.$set(this.form, 'loading', newValue)
+                this.$set(this.$root.form, 'loading', newValue)
             },
         },
 
         formHasErrors: {
             get() {
-                return Object.keys(this.form.errors).length > 0
+                return Object.keys(this.formErrors).length > 0
             },
         },
 
@@ -63,22 +74,22 @@ export default {
         },
 
         clearFormErrors() {
-            this.$set(this.form, 'errors', {})
+            this.formErrors = {}
         },
 
         setFormErrors(response) {
             if (!response) return
 
-            this.$set(this.form, 'errors', response.data.errors)
+            this.$set(this, 'formErrors', response.data.errors)
         },
 
         formError(field) {
-            if (!this.form.errors) return false
+            if (!this.formErrors) return false
 
-            if (typeof this.form.errors[field] === 'string') return this.form.errors[field]
-            if (typeof this.form.errors[field] === 'undefined') return ''
+            if (typeof this.formErrors[field] === 'string') return this.formErrors[field]
+            if (typeof this.formErrors[field] === 'undefined') return ''
 
-            return this.form.errors[field][0]
+            return this.formErrors[field][0]
         },
 
         formFieldValid(element) {
@@ -89,6 +100,7 @@ export default {
             if (!response.status) return
 
             this.$set(this.form, 'status', response.status)
+            this.$set(this.$root.form, 'status', response.status)
         },
 
         getForm(formTarget, formData, formRef = 'form') {


### PR DESCRIPTION
FormMixin now sets and checks local and root state form errors to provide better compatibility when working with sub-components. Have tested on FFT repo without any unwanted side-effects as far as I could tell and should be backwards-compatible.